### PR TITLE
Feat: 주문 페이지 버튼 기능구현

### DIFF
--- a/src/main/resources/static/css/example_style.css
+++ b/src/main/resources/static/css/example_style.css
@@ -64,3 +64,9 @@ hr {
 .del-button {
     width: 38px;
 }
+
+.inform {
+    color: crimson;
+    font-size: 0.8rem;
+    padding-bottom: 0.5rem;
+}

--- a/src/main/resources/static/css/example_style.css
+++ b/src/main/resources/static/css/example_style.css
@@ -1,0 +1,66 @@
+
+body {
+    background: #f5f5f5;
+}
+
+.card {
+    margin: auto;
+    max-width: 950px;
+    width: 90%;
+    box-shadow: 0 6px 20px 0 rgba(38, 38, 38, 0.19);
+    border-radius: 1rem;
+    border: transparent
+}
+
+.summary {
+    background-color: #ddd;
+    border-top-right-radius: 1rem;
+    border-bottom-right-radius: 1rem;
+    padding: 4vh;
+    color: rgb(65, 65, 65)
+}
+
+@media (max-width: 767px) {
+    .summary {
+        border-top-right-radius: unset;
+        border-bottom-left-radius: 1rem
+    }
+}
+
+.row {
+    margin: 0
+}
+
+.title b {
+    font-size: 1.5rem
+}
+
+.col-2,
+.col {
+    padding: 0 1vh
+}
+
+img {
+    width: 3.5rem
+}
+
+hr {
+    margin-top: 1.25rem
+}
+.products {
+    width: 100%;
+}
+.products .price, .products .action {
+    line-height: 38px;
+}
+.products .action {
+    line-height: 38px;
+}
+
+.add-button {
+    width: 38px;
+}
+
+.del-button {
+    width: 38px;
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -8,74 +8,18 @@
   <!-- Bootstrap CSS -->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
-  <style>
-    body {
-      background: #f5f5f5;
-    }
 
-    .card {
-      margin: auto;
-      max-width: 950px;
-      width: 90%;
-      box-shadow: 0 6px 20px 0 rgba(38, 38, 38, 0.19);
-      border-radius: 1rem;
-      border: transparent
-    }
+  <!-- style 부분만 분리 -->
+  <link rel="stylesheet" href="/css/example_style.css">
 
-    .summary {
-      background-color: #ddd;
-      border-top-right-radius: 1rem;
-      border-bottom-right-radius: 1rem;
-      padding: 4vh;
-      color: rgb(65, 65, 65)
-    }
-
-    @media (max-width: 767px) {
-      .summary {
-        border-top-right-radius: unset;
-        border-bottom-left-radius: 1rem
-      }
-    }
-
-    .row {
-      margin: 0
-    }
-
-    .title b {
-      font-size: 1.5rem
-    }
-
-    .col-2,
-    .col {
-      padding: 0 1vh
-    }
-
-    img {
-      width: 3.5rem
-    }
-
-    hr {
-      margin-top: 1.25rem
-    }
-    .products {
-      width: 100%;
-    }
-    .products .price, .products .action {
-      line-height: 38px;
-    }
-    .products .action {
-      line-height: 38px;
-    }
-
-
-
-  </style>
   <title>Grids & Circle | 주문 페이지</title>
 </head>
+
 <body class="container-fluid">
 <div class="row justify-content-center m-4">
   <h1 class="text-center">Grids & Circle</h1>
 </div>
+
 <div class="card">
   <div class="row">
     <div class="col-md-8 mt-4 d-flex flex-column align-items-start p-3 pt-0">
@@ -89,7 +33,10 @@
             <div class="row">Columbia Nariñó</div>
           </div>
           <div class="col text-center price">5000원</div>
-          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
+          <div class="col text-end action">
+            <a class="btn btn-small btn-outline-dark del-button" href="">-</a>
+            <a class="btn btn-small btn-outline-dark add-button" href="">+</a>
+          </div>
         </li>
 
         <li class="list-group-item d-flex mt-2" data-name="brazil">
@@ -99,11 +46,10 @@
             <div class="row">Brazil Serra Do Caparaó</div>
           </div>
           <div class="col text-center price">5000원</div>
-          <!-- <div class="col text-end action"><a class="btn btn-small btn-outline-dark rounded-circle" href="" style="white-space: pre;"> - </a></div> -->
-          <!-- <div class="row text-center price">2개</div> -->
-          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
-          <!-- 추가 -->
-          <!-- <button class="round-btn">+</button> -->
+          <div class="col text-end action">
+            <a class="btn btn-small btn-outline-dark del-button" href="">-</a>
+            <a class="btn btn-small btn-outline-dark add-button" href="">+</a>
+          </div>
         </li>
 
         <li class="list-group-item d-flex mt-2" data-name="arabica">
@@ -113,10 +59,14 @@
             <div class="row">Arabica</div>
           </div>
           <div class="col text-center price">5000원</div>
-          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
+          <div class="col text-end action">
+            <a class="btn btn-small btn-outline-dark del-button" href="">-</a>
+            <a class="btn btn-small btn-outline-dark add-button" href="">+</a>
+          </div>
         </li>
       </ul>
     </div>
+
     <div class="col-md-4 summary p-4">
       <div>
         <h5 class="m-0 p-0"><b>Summary</b></h5>
@@ -131,6 +81,7 @@
       <div class="row">
         <h6 class="p-0">Arabica <span class="product-count badge bg-dark" data-name="arabica">0개</span></h6>
       </div>
+
       <form>
         <div class="mb-3">
           <label for="email" class="form-label">이메일</label>
@@ -146,16 +97,20 @@
         </div>
         <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
       </form>
+
       <div class="row pt-2 pb-2 border-top">
         <h5 class="col">총금액</h5>
         <h5 class="col text-end">15000원</h5>
       </div>
+
       <button class="btn btn-dark col-12 order-btn">결제하기</button>
+
     </div>
   </div>
 </div>
 
 <script>
+  // + 누르면 개수 증가
   document.querySelectorAll('.add-button').forEach(function(btn) {
     btn.addEventListener('click', function(e) {
       e.preventDefault(); // a태그 새로고침 방지
@@ -171,6 +126,24 @@
         // "2개" → 2
         let count = parseInt(summaryCount.textContent);
         summaryCount.textContent = (count + 1) + "개";
+      }
+    });
+  });
+
+  // - 누르면 개수 증가
+  document.querySelectorAll('.del-button').forEach(function(btn) {
+    btn.addEventListener('click', function(e) {
+      e.preventDefault(); // a태그 새로고침 방지
+
+      const li = btn.closest('li');
+      const coffeeName = li.getAttribute('data-name');
+
+      const summaryCount = document.querySelector('.summary .product-count[data-name="' + coffeeName + '"]');
+      if (summaryCount) {
+        let count = parseInt(summaryCount.textContent);
+        if (count >= 1){
+          summaryCount.textContent = (count - 1) + "개";
+        }
       }
     });
   });

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -95,11 +95,11 @@
           <label for="postcode" class="form-label">우편번호</label>
           <input type="text" class="form-control" id="postcode">
         </div>
-        <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
+        <div class="inform">당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
       </form>
 
       <div class="row pt-2 pb-2 border-top">
-        <h5 class="col">총금액</h5>
+        <h5 class="col">총 금액</h5>
         <h5 class="col text-end">15000원</h5>
       </div>
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <!-- Required meta tags -->
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+  <style>
+    body {
+      background: #f5f5f5;
+    }
+
+    .card {
+      margin: auto;
+      max-width: 950px;
+      width: 90%;
+      box-shadow: 0 6px 20px 0 rgba(38, 38, 38, 0.19);
+      border-radius: 1rem;
+      border: transparent
+    }
+
+    .summary {
+      background-color: #ddd;
+      border-top-right-radius: 1rem;
+      border-bottom-right-radius: 1rem;
+      padding: 4vh;
+      color: rgb(65, 65, 65)
+    }
+
+    @media (max-width: 767px) {
+      .summary {
+        border-top-right-radius: unset;
+        border-bottom-left-radius: 1rem
+      }
+    }
+
+    .row {
+      margin: 0
+    }
+
+    .title b {
+      font-size: 1.5rem
+    }
+
+    .col-2,
+    .col {
+      padding: 0 1vh
+    }
+
+    img {
+      width: 3.5rem
+    }
+
+    hr {
+      margin-top: 1.25rem
+    }
+    .products {
+      width: 100%;
+    }
+    .products .price, .products .action {
+      line-height: 38px;
+    }
+    .products .action {
+      line-height: 38px;
+    }
+
+
+
+  </style>
+  <title>Grids & Circle | 주문 페이지</title>
+</head>
+<body class="container-fluid">
+<div class="row justify-content-center m-4">
+  <h1 class="text-center">Grids & Circle</h1>
+</div>
+<div class="card">
+  <div class="row">
+    <div class="col-md-8 mt-4 d-flex flex-column align-items-start p-3 pt-0">
+      <h5 class="flex-grow-0"><b>상품 목록</b></h5>
+      <ul class="list-group products">
+
+        <li class="list-group-item d-flex mt-3" data-name="columbia">
+          <div class="col-2"><img class="img-fluid" src="https://i.imgur.com/HKOFQYa.jpeg" alt=""></div>
+          <div class="col">
+            <div class="row text-muted">커피콩</div>
+            <div class="row">Columbia Nariñó</div>
+          </div>
+          <div class="col text-center price">5000원</div>
+          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
+        </li>
+
+        <li class="list-group-item d-flex mt-2" data-name="brazil">
+          <div class="col-2"><img class="img-fluid" src="https://i.imgur.com/HKOFQYa.jpeg" alt=""></div>
+          <div class="col">
+            <div class="row text-muted">커피콩</div>
+            <div class="row">Brazil Serra Do Caparaó</div>
+          </div>
+          <div class="col text-center price">5000원</div>
+          <!-- <div class="col text-end action"><a class="btn btn-small btn-outline-dark rounded-circle" href="" style="white-space: pre;"> - </a></div> -->
+          <!-- <div class="row text-center price">2개</div> -->
+          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
+          <!-- 추가 -->
+          <!-- <button class="round-btn">+</button> -->
+        </li>
+
+        <li class="list-group-item d-flex mt-2" data-name="arabica">
+          <div class="col-2"><img class="img-fluid" src="https://i.imgur.com/HKOFQYa.jpeg" alt=""></div>
+          <div class="col">
+            <div class="row text-muted">커피콩</div>
+            <div class="row">Arabica</div>
+          </div>
+          <div class="col text-center price">5000원</div>
+          <div class="col text-end action"><a class="btn btn-small btn-outline-dark add-button" href="">추가</a></div>
+        </li>
+      </ul>
+    </div>
+    <div class="col-md-4 summary p-4">
+      <div>
+        <h5 class="m-0 p-0"><b>Summary</b></h5>
+      </div>
+      <hr>
+      <div class="row">
+        <h6 class="p-0">Columbia Nariñó <span class="product-count badge bg-dark text-" data-name="columbia">0개</span></h6>
+      </div>
+      <div class="row">
+        <h6 class="p-0">Brazil Serra Do Caparaó <span class="product-count badge bg-dark" data-name="brazil">0개</span></h6>
+      </div>
+      <div class="row">
+        <h6 class="p-0">Arabica <span class="product-count badge bg-dark" data-name="arabica">0개</span></h6>
+      </div>
+      <form>
+        <div class="mb-3">
+          <label for="email" class="form-label">이메일</label>
+          <input type="email" class="form-control mb-1" id="email">
+        </div>
+        <div class="mb-3">
+          <label for="address" class="form-label">주소</label>
+          <input type="text" class="form-control mb-1" id="address">
+        </div>
+        <div class="mb-3">
+          <label for="postcode" class="form-label">우편번호</label>
+          <input type="text" class="form-control" id="postcode">
+        </div>
+        <div>당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
+      </form>
+      <div class="row pt-2 pb-2 border-top">
+        <h5 class="col">총금액</h5>
+        <h5 class="col text-end">15000원</h5>
+      </div>
+      <button class="btn btn-dark col-12 order-btn">결제하기</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  document.querySelectorAll('.add-button').forEach(function(btn) {
+    btn.addEventListener('click', function(e) {
+      e.preventDefault(); // a태그 새로고침 방지
+
+      // 1. 어떤 커피인지 data-name으로 구분
+      // (li에 data-name이 있다면)
+      const li = btn.closest('li');
+      const coffeeName = li.getAttribute('data-name');
+
+      // 2. summary에서 같은 data-name을 가진 .product-count 찾기
+      const summaryCount = document.querySelector('.summary .product-count[data-name="' + coffeeName + '"]');
+      if (summaryCount) {
+        // "2개" → 2
+        let count = parseInt(summaryCount.textContent);
+        summaryCount.textContent = (count + 1) + "개";
+      }
+    });
+  });
+
+  // 결제하기 눌렀을 떄 팝업 메세지 생성
+  document.querySelector('.order-btn').addEventListener('click', function() {
+    const counts = {};
+    document.querySelectorAll('.product-count').forEach(function(span) {
+      const name = span.dataset.name;
+      counts[name] = parseInt(span.textContent);
+    });
+
+    const message = "주문이 성공적으로 완료되었습니다.\n\n" +
+        "----- 주문 내역 -----\n";
+
+    const contents = [];
+    for (const [key, value] of Object.entries(counts)) {
+      contents.push(key + ":" + value + "개");
+    }
+
+
+    const deliveryMessage = "\n\n ----- 배송 정보 확인 -----\n"
+    const deliveryInfo = [];
+    deliveryInfo.push("이메일 : " + document.getElementById('email').value);
+    deliveryInfo.push("주소 : " + document.getElementById('address').value);
+    deliveryInfo.push("우편번호 : " + document.getElementById('postcode').value);
+
+    const orderJson = message + contents.join("\n") + deliveryMessage + deliveryInfo.join("\n");
+
+    alert(orderJson);
+  });
+
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 🛰️ Issue Number
#3 

## 🪐 작업 내용
- 추가하기 버튼 대신 -, + 버튼으로 수량 조정 기능 추가
    - "-" 버튼은 수량이 0개일 경우 더 감소시키지 않습니다.
    
- 배송 안내 문구 색, 크기, padding 조정하여 더 잘 보이도록 했습니다.

- 결제하기 버튼 클릭 시 아래 정보들을 alert 팝업으로 보여줍니다.
    - 주문한 커피 이름 : 개수 
    - 배송정보 (이메일, 주소, 우편번호)
   
→ 현재는 getElementById로 가져오는데, 추후에는 결제하기 버튼 클릭 - 요청전송 - 받은 응답에서 Order의 필드들을 가져와서 팝업에 표시할 예정입니다.

- +- 버튼으로 수량 조절했을 때 오른쪽에 각 커피마다 다르게 설정된 화면
![image](https://github.com/user-attachments/assets/4f25e720-4b4b-4db5-beb2-90fa6e623a87)

- 결제하기 버튼을 눌렀을 때 뜨는 alert 팝업
![image](https://github.com/user-attachments/assets/66b04cf2-9702-4fd9-839e-f3ee673aafe8)


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?