### PR TITLE
Feat: Order CR 구현

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
@@ -1,0 +1,9 @@
+package io.sleepyhoon.project1.dao;
+
+import io.sleepyhoon.project1.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
@@ -4,6 +4,13 @@ import io.sleepyhoon.project1.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
+
+    Optional<Order> findByEmailAndAddress(String email, String Address);
+
+    List<Order> findByEmail(String email);
 }

--- a/src/main/java/io/sleepyhoon/project1/dto/OrderDto.java
+++ b/src/main/java/io/sleepyhoon/project1/dto/OrderDto.java
@@ -1,0 +1,19 @@
+package io.sleepyhoon.project1.dto;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderDto {
+
+    private String email;
+    private String address;
+    private String postNum;
+
+    @Builder
+    public OrderDto(String email, String address, String postNum) {
+        this.email = email;
+        this.address = address;
+        this.postNum = postNum;
+    }
+}

--- a/src/main/java/io/sleepyhoon/project1/entity/Order.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Order.java
@@ -26,7 +26,7 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)

--- a/src/main/java/io/sleepyhoon/project1/service/OrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/OrderService.java
@@ -1,0 +1,41 @@
+package io.sleepyhoon.project1.service;
+
+
+
+import io.sleepyhoon.project1.dao.OrderRepository;
+import io.sleepyhoon.project1.dto.OrderDto;
+import io.sleepyhoon.project1.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OrderService {
+
+
+    private final OrderRepository orderRepository;
+
+    public Order save(OrderDto orderDto) {
+
+        Optional<Order> orderOptional = orderRepository.findByEmailAndAddress(orderDto.getEmail(), orderDto.getAddress());
+
+        return orderOptional.orElseGet(() -> orderRepository.save(
+                Order.builder()
+                        .email(orderDto.getEmail())
+                        .address(orderDto.getAddress())
+                        .postNum(orderDto.getPostNum())
+                        .build()
+        ));
+    }
+
+    public List<Order> findByEmailAllOrders(String email) {
+        return orderRepository.findByEmail(email);
+    }
+
+
+}

--- a/src/test/java/io/sleepyhoon/project1/service/OrderServiceTests.java
+++ b/src/test/java/io/sleepyhoon/project1/service/OrderServiceTests.java
@@ -1,0 +1,70 @@
+package io.sleepyhoon.project1.service;
+
+import io.sleepyhoon.project1.dto.OrderDto;
+import io.sleepyhoon.project1.entity.Order;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class OrderServiceTests {
+
+    @Autowired
+    OrderService orderService;
+
+    @Test
+    @Rollback(false)
+    @DisplayName("Order 저장 테스트")
+    void orderSaveTest() throws Exception {
+
+        OrderDto orderDto = OrderDto.builder()
+                .email("h1@h1.com")
+                .address("경기도")
+                .postNum("12345")
+                .build();
+
+        Order saved = orderService.save(orderDto);
+        assertThat(saved).isNotNull();
+    }
+
+    @Test
+    @DisplayName("email에 해당하는 주문 리스트 읽기")
+    void readAllOrders() throws Exception {
+
+        OrderDto orderDto1 = OrderDto.builder()
+                .email("h1@h1.com")
+                .address("화성")
+                .postNum("12345")
+                .build();
+        orderService.save(orderDto1);
+        OrderDto orderDto2 = OrderDto.builder()
+                .email("h1@h1.com")
+                .address("경기도")
+                .postNum("12345")
+                .build();
+        orderService.save(orderDto2);
+        OrderDto orderDto3 = OrderDto.builder()
+                .email("h1@h1.com")
+                .address("서울")
+                .postNum("12345")
+                .build();
+        orderService.save(orderDto3);
+
+
+        List<Order> orderList = orderService.findByEmailAllOrders("h1@h1.com");
+
+        assertThat(orderList).isNotNull();
+        assertThat(orderList.size()).isEqualTo(3);
+
+    }
+
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#4

## 🪐 작업 내용
Order의 CR을 구현했습니다.

#### Create
1. OrderDto 객체로 이메일, 주소, 우편번호를 생성한다.
2. OrderService의 save함수의 매개변수로 orderDto를 입력받는다.
3. 입력받은 orderDto 객체의 이메일과 주소를 확인하여 Optional로 객체를 반환한다.
4. Optional 객체가 존재하지 않는다면 새로운 Order 객체를 생성하고 반환한다.
5. Optional 객체가 존재한다면 해당 객체를 반환한다.

#### Read
- findByEmail 함수를 통해 해당 이메일과 같은 주문을 List 형태로 반환한다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?