### PR TITLE
Fix: test버그 수정

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CoffeeRepository extends JpaRepository<Coffee, Long> {
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        formagit t_sql: true
+        format t_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql: true
+        formagit t_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,4 +11,4 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format t_sql: true
+        format_sql: true


### PR DESCRIPTION
## 🛰️ Issue Number
#12 

## 🪐 작업 내용
- Service의 save의 반환타입을 Long으로 바꿨기 때문에 오류가 발생했었고,
id는 setter가 없기에 리플렉션을 통해 id값을 설정하는 식으로 테스트진행함.

- findById_whenCoffeeDoesNotExist()에서도 예외가 발생했는데. 이는 assertThrows()에 도달하기 전에 예외가 먼저 터져버려서 예외가 assertThrows()에 도달하지 못해 테스트 실패했었음. 이를 assertThrows에서만 예외 발생하도록 함.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?