### PR TITLE
feat: 중복이름 커피 검사 기능 구현

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
@@ -4,7 +4,10 @@ import io.sleepyhoon.project1.entity.Coffee;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CoffeeRepository extends JpaRepository<Coffee, Long> {
 
+    List<Coffee> findByName(String name);
 }

--- a/src/main/java/io/sleepyhoon/project1/exception/CoffeeDuplicationException.java
+++ b/src/main/java/io/sleepyhoon/project1/exception/CoffeeDuplicationException.java
@@ -1,7 +1,8 @@
 package io.sleepyhoon.project1.exception;
 
-public class DataDuplicationException extends RuntimeException {
-  public DataDuplicationException(String message) {
-    super(message);
-  }
+public class CoffeeDuplicationException extends RuntimeException {
+    public CoffeeDuplicationException(String message) {
+        super(
+                "A coffee with " + message + " already exists.");
+    }
 }

--- a/src/main/java/io/sleepyhoon/project1/exception/CoffeeDuplicationException.java
+++ b/src/main/java/io/sleepyhoon/project1/exception/CoffeeDuplicationException.java
@@ -1,0 +1,7 @@
+package io.sleepyhoon.project1.exception;
+
+public class DataDuplicationException extends RuntimeException {
+  public DataDuplicationException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/io/sleepyhoon/project1/exception/GlobalExceptionHandler.java
+++ b/src/main/java/io/sleepyhoon/project1/exception/GlobalExceptionHandler.java
@@ -9,15 +9,21 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 //예외를 json으로 보내준다.
-@ResponseStatus(HttpStatus.NOT_FOUND)
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(CoffeeNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleCoffeeNotFound(CoffeeNotFoundException e) {
         ErrorResponseDto response = new ErrorResponseDto("COFFEE_NOT_FOUND", e.getMessage(), 404);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
 
+    }
 
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(CoffeeDuplicationException.class)
+    public ResponseEntity<ErrorResponseDto> handleCoffeeDuplication(CoffeeDuplicationException e) {
+        ErrorResponseDto response = new ErrorResponseDto("COFFEE_DUPLICATION", e.getMessage(), 409);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
 }

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
@@ -4,6 +4,7 @@ import io.sleepyhoon.project1.dao.CoffeeRepository;
 import io.sleepyhoon.project1.dto.CoffeeRequestDto;
 import io.sleepyhoon.project1.dto.CoffeeResponseDto;
 import io.sleepyhoon.project1.entity.Coffee;
+import io.sleepyhoon.project1.exception.CoffeeDuplicationException;
 import io.sleepyhoon.project1.exception.CoffeeNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,13 @@ public class CoffeeService {
 
         return coffeeRepository.findById(id)
                .orElseThrow(() -> new CoffeeNotFoundException(id));
+    }
+
+    public void checkDuplication(String coffeeName) {
+        List<Coffee> byName = coffeeRepository.findByName(coffeeName);
+        if (!byName.isEmpty()) {
+            throw new CoffeeDuplicationException(coffeeName);
+        }
     }
 
     public List<CoffeeResponseDto> findEveryCoffee() {
@@ -48,6 +56,9 @@ public class CoffeeService {
                 .price(requestDto.getPrice())
                 .img(requestDto.getImg())
                 .build();
+
+        checkDuplication(newCoffee.getName());
+
         return coffeeRepository.save(newCoffee).getId();
 
     }


### PR DESCRIPTION
## 🛰️ Issue Number
#20 

## 🪐 작업 내용
Coffee save시 이름기준으로 중복검사를 구현했습니다.
같은 이름의 커피가 이미 DB에 존재한다면 CoffeeDuplicationException를 터트립니다.
이는 다음과 같은 JSON형식으로 응답됩니다.
```
{
    "error": {
        "code": "COFFEE_DUPLICATION",
        "message": "A coffee with testCoffee already exists."
    },
    "status": 409,
    "timestamp": "2025-04-24T11:29:20.238028"
}
```
## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?