### PR TITLE
feat: img수정기능 및 dto빌드시 img누락 수정

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
@@ -33,6 +33,7 @@ public class CoffeeService {
                     .id(coffee.getId())
                     .name(coffee.getName())
                     .price(coffee.getPrice())
+                    .img(coffee.getImg())
                     .build();
 
             coffeeListDto.add(responseCoffeeDto);
@@ -68,6 +69,10 @@ public class CoffeeService {
 
         if (requestDto.getPrice() != null) {
             targetCoffee.setPrice(requestDto.getPrice());
+        }
+
+        if (requestDto.getImg() != null) {
+            targetCoffee.setImg(requestDto.getImg());
         }
 
         return targetCoffee;

--- a/src/test/java/io/sleepyhoon/project1/coffeetests/CoffeeServiceTest.java
+++ b/src/test/java/io/sleepyhoon/project1/coffeetests/CoffeeServiceTest.java
@@ -111,13 +111,14 @@ class CoffeeServiceTest {
     void update_when() {
         // given
         Long coffeeId = 1L;
+        Coffee existingCoffee = createCoffeeWithId(coffeeId,"Latte",4000,"개쩌는 사진링크");
 
-        Coffee existingCoffee = new Coffee("Latte",4000,"개쩌는 사진링크");
-//        existingCoffee.setId(coffeeId);
 
-        CoffeeRequestDto requestDto = new CoffeeRequestDto();
-        requestDto.setName("Cappuccino");
-        requestDto.setPrice(4500);
+        CoffeeRequestDto requestDto = CoffeeRequestDto.builder()
+                .name("newLatte")
+                .price(1000)
+                .img("새로운 라테 사진")
+                .build();
 
         // findById가 호출되면 existingCoffee를 반환
         when(coffeeRepository.findById(coffeeId)).thenReturn(Optional.of(existingCoffee));
@@ -126,12 +127,13 @@ class CoffeeServiceTest {
         Coffee result = coffeeService.update(coffeeId, requestDto);
 
         // then
-        assertEquals("Cappuccino", result.getName());
-        assertEquals(4500, result.getPrice());
+        assertEquals("newLatte", result.getName());
+        assertEquals(1000, result.getPrice());
+        assertEquals("새로운 라테 사진", result.getImg());
 
         // 실제로 커피 객체가 수정되었는지도 확인
-        assertEquals("Cappuccino", existingCoffee.getName());
-        assertEquals(4500, existingCoffee.getPrice());
+        assertEquals("newLatte", existingCoffee.getName());
+        assertEquals(1000, existingCoffee.getPrice());
 
         // 리포지토리 호출 확인
         verify(coffeeRepository).findById(coffeeId);


### PR DESCRIPTION
## 🛰️ Issue Number
#22 

## 🪐 작업 내용
update메소드에서 img도 수정가능하게 수정하였습니다.
요청이 img만 들어와도 다른 필드는 null로 수정하지 않고 img만 수정합니다.
다른 필드도 마찬가지입니다.

추가로 findEveryCoffee에서 img 빌드 누락한것 수정했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?