### PR TITLE
Feat/19 coffeeorder crud

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/dao/CoffeeOrderRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/CoffeeOrderRepository.java
@@ -1,0 +1,10 @@
+package io.sleepyhoon.project1.dao;
+
+import io.sleepyhoon.project1.entity.CoffeeOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CoffeeOrderRepository extends JpaRepository<CoffeeOrder, Integer> {
+
+}

--- a/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/CoffeeRepository.java
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CoffeeRepository extends JpaRepository<Coffee, Long> {
 
     List<Coffee> findByName(String name);
+
+    Optional<Coffee> findFirstByName(String name);
 }

--- a/src/main/java/io/sleepyhoon/project1/dto/CoffeeListDto.java
+++ b/src/main/java/io/sleepyhoon/project1/dto/CoffeeListDto.java
@@ -1,0 +1,13 @@
+package io.sleepyhoon.project1.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CoffeeListDto {
+    private String coffeeName;
+    private Integer quantity;
+}

--- a/src/main/java/io/sleepyhoon/project1/dto/CoffeeOrderDto.java
+++ b/src/main/java/io/sleepyhoon/project1/dto/CoffeeOrderDto.java
@@ -1,0 +1,23 @@
+package io.sleepyhoon.project1.dto;
+
+import io.sleepyhoon.project1.entity.Coffee;
+import io.sleepyhoon.project1.entity.Order;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class CoffeeOrderDto {
+
+    private Coffee coffee;
+    private Integer quantity;
+    private Order order;
+
+    @Builder
+    public CoffeeOrderDto(Coffee coffee, Integer quantity, Order order) {
+        this.coffee = coffee;
+        this.quantity = quantity;
+        this.order = order;
+    }
+}

--- a/src/main/java/io/sleepyhoon/project1/entity/Coffee.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Coffee.java
@@ -16,7 +16,7 @@ public class Coffee {
     private Long id;
 
     @Setter
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     @Setter

--- a/src/main/java/io/sleepyhoon/project1/entity/CoffeeOrder.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/CoffeeOrder.java
@@ -2,8 +2,10 @@ package io.sleepyhoon.project1.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 
 @Entity
 @Getter
@@ -25,4 +27,12 @@ public class CoffeeOrder {
 
     @Column(nullable = false)
     private Integer quantity;
+
+    @Builder
+    public CoffeeOrder(Coffee coffee, Order order, Integer quantity) {
+        this.coffee = coffee;
+        this.order = order;
+        this.quantity = quantity;
+    }
+
 }

--- a/src/main/java/io/sleepyhoon/project1/entity/CoffeeOrder.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/CoffeeOrder.java
@@ -28,11 +28,15 @@ public class CoffeeOrder {
     @Column(nullable = false)
     private Integer quantity;
 
+    @Column(nullable = false)
+    private Integer subtotalPrice;
+
     @Builder
     public CoffeeOrder(Coffee coffee, Order order, Integer quantity) {
         this.coffee = coffee;
         this.order = order;
         this.quantity = quantity;
+        this.subtotalPrice = coffee.getPrice() * quantity;
     }
 
 }

--- a/src/main/java/io/sleepyhoon/project1/entity/Order.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Order.java
@@ -33,7 +33,7 @@ public class Order {
     private Boolean isProcessed = false;
 
     @Setter
-    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CoffeeOrder> coffeeOrders;
 
     @Builder

--- a/src/main/java/io/sleepyhoon/project1/entity/Order.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Order.java
@@ -32,6 +32,7 @@ public class Order {
     @Column(nullable = false)
     private Boolean isProcessed = false;
 
+    @Setter
     @OneToMany(mappedBy = "order", fetch = FetchType.LAZY)
     private List<CoffeeOrder> coffeeOrders;
 
@@ -41,4 +42,5 @@ public class Order {
         this.address = address;
         this.postNum = postNum;
     }
+
 }

--- a/src/main/java/io/sleepyhoon/project1/exception/CoffeeNotFoundException.java
+++ b/src/main/java/io/sleepyhoon/project1/exception/CoffeeNotFoundException.java
@@ -4,4 +4,8 @@ public class CoffeeNotFoundException extends RuntimeException {
     public CoffeeNotFoundException(Long id) {
         super("Coffee with id " + id + " not found");
     }
+
+    public CoffeeNotFoundException(String name) {
+        super("Coffee named " + name + " not found");
+    }
 }

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
@@ -1,6 +1,7 @@
 package io.sleepyhoon.project1.service;
 
 import io.sleepyhoon.project1.dao.CoffeeOrderRepository;
+import io.sleepyhoon.project1.dto.CoffeeListDto;
 import io.sleepyhoon.project1.dto.CoffeeOrderDto;
 import io.sleepyhoon.project1.entity.Coffee;
 import io.sleepyhoon.project1.entity.CoffeeOrder;
@@ -21,12 +22,13 @@ public class CoffeeOrderService {
     private final CoffeeService coffeeService;
     private final CoffeeOrderRepository coffeeOrderRepository;
 
-    public List<CoffeeOrder> genCoffeeOrderList(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
+    public List<CoffeeOrder> genCoffeeOrderList(List<CoffeeListDto> requestCoffeeList, Order orderRequest) {
 
-        List<CoffeeOrder> coffeeOrderList = new ArrayList<>();
-        for(Map.Entry<String, Integer> entry : coffeeOrderMap.entrySet()) {
-            String coffeeName = entry.getKey();
-            Integer coffeeQuantity = entry.getValue();
+        List<CoffeeOrder> responseCoffeeOrderList = new ArrayList<>();
+        for(CoffeeListDto coffeeListDto : requestCoffeeList) {
+
+            String coffeeName = coffeeListDto.getCoffeeName();
+            Integer coffeeQuantity = coffeeListDto.getQuantity();
 
             Coffee coffeeInOrder = coffeeService.findFirstCoffeeByName(coffeeName);
 
@@ -37,10 +39,11 @@ public class CoffeeOrderService {
                     .build();
 
             //CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);
-            coffeeOrderList.add(coffeeOrder);
+            responseCoffeeOrderList.add(coffeeOrder);
         }
-        return coffeeOrderList;
+        return responseCoffeeOrderList;
     }
+
 
 }
 

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
@@ -1,0 +1,45 @@
+package io.sleepyhoon.project1.service;
+
+import io.sleepyhoon.project1.dao.CoffeeOrderRepository;
+import io.sleepyhoon.project1.dto.CoffeeOrderDto;
+import io.sleepyhoon.project1.entity.Coffee;
+import io.sleepyhoon.project1.entity.CoffeeOrder;
+import io.sleepyhoon.project1.entity.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CoffeeOrderService {
+    private final CoffeeService coffeeService;
+    private final CoffeeOrderRepository coffeeOrderRepository;
+
+    public Order save(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
+
+        List<CoffeeOrder> coffeeOrderList = new LinkedList<>();
+        for(Map.Entry<String, Integer> entry : coffeeOrderMap.entrySet()) {
+            String coffeeName = entry.getKey();
+            Integer coffeeQuantity = entry.getValue();
+
+            Coffee coffeeInOrder = coffeeService.findFirstCoffeeByName(coffeeName);
+
+            CoffeeOrder coffeeOrder = CoffeeOrder.builder()
+                    .coffee(coffeeInOrder)
+                    .order(orderRequest)
+                    .quantity(coffeeQuantity)
+                    .build();
+
+            CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);
+            coffeeOrderList.add(saved);
+        }
+        orderRequest.setCoffeeOrders(coffeeOrderList);
+        return orderRequest;
+    }
+
+}

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -20,9 +21,9 @@ public class CoffeeOrderService {
     private final CoffeeService coffeeService;
     private final CoffeeOrderRepository coffeeOrderRepository;
 
-    public Order save(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
+    public List<CoffeeOrder> save(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
 
-        List<CoffeeOrder> coffeeOrderList = new LinkedList<>();
+        List<CoffeeOrder> coffeeOrderList = new ArrayList<>();
         for(Map.Entry<String, Integer> entry : coffeeOrderMap.entrySet()) {
             String coffeeName = entry.getKey();
             Integer coffeeQuantity = entry.getValue();
@@ -38,8 +39,9 @@ public class CoffeeOrderService {
             CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);
             coffeeOrderList.add(saved);
         }
-        orderRequest.setCoffeeOrders(coffeeOrderList);
-        return orderRequest;
+        return coffeeOrderList;
     }
 
 }
+
+

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeOrderService.java
@@ -21,7 +21,7 @@ public class CoffeeOrderService {
     private final CoffeeService coffeeService;
     private final CoffeeOrderRepository coffeeOrderRepository;
 
-    public List<CoffeeOrder> save(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
+    public List<CoffeeOrder> genCoffeeOrderList(Map<String, Integer> coffeeOrderMap, Order orderRequest) {
 
         List<CoffeeOrder> coffeeOrderList = new ArrayList<>();
         for(Map.Entry<String, Integer> entry : coffeeOrderMap.entrySet()) {
@@ -36,8 +36,8 @@ public class CoffeeOrderService {
                     .quantity(coffeeQuantity)
                     .build();
 
-            CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);
-            coffeeOrderList.add(saved);
+            //CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);
+            coffeeOrderList.add(coffeeOrder);
         }
         return coffeeOrderList;
     }

--- a/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/CoffeeService.java
@@ -27,6 +27,12 @@ public class CoffeeService {
                .orElseThrow(() -> new CoffeeNotFoundException(id));
     }
 
+    //Coffee Name으로 커피 조회
+    public Coffee findFirstCoffeeByName(String coffeeName) {
+        return coffeeRepository.findFirstByName(coffeeName)
+                .orElseThrow(() -> new CoffeeNotFoundException(coffeeName));
+    }
+
     public void checkDuplication(String coffeeName) {
         List<Coffee> byName = coffeeRepository.findByName(coffeeName);
         if (!byName.isEmpty()) {

--- a/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
+++ b/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
@@ -98,7 +98,8 @@ public class CoffeeOrderServiceTest {
 
         //when
         List<CoffeeOrder> actualCoffeeOrders=
-                coffeeOrderService.save(coffeeOrderRequestDtoMap, testOrder);
+                coffeeOrderService.genCoffeeOrderList(coffeeOrderRequestDtoMap, testOrder);
+
         //순서보장이 안되서 테스트 실패하는 경우가 있어서 정렬 후 검증
         actualCoffeeOrders.sort(Comparator.comparing(o -> o.getCoffee().getName()));
 

--- a/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
+++ b/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
@@ -1,0 +1,117 @@
+package io.sleepyhoon.project1.coffeeordertests;
+
+import io.sleepyhoon.project1.dao.CoffeeOrderRepository;
+import io.sleepyhoon.project1.dao.CoffeeRepository;
+import io.sleepyhoon.project1.dao.OrderRepository;
+import io.sleepyhoon.project1.dto.CoffeeOrderDto;
+import io.sleepyhoon.project1.dto.CoffeeRequestDto;
+import io.sleepyhoon.project1.entity.Coffee;
+import io.sleepyhoon.project1.entity.CoffeeOrder;
+import io.sleepyhoon.project1.entity.Order;
+import io.sleepyhoon.project1.service.CoffeeOrderService;
+import io.sleepyhoon.project1.service.CoffeeService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.stubbing.OngoingStubbing;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@Slf4j
+@SpringBootTest
+public class CoffeeOrderServiceTest {
+
+    @Autowired
+    private CoffeeOrderService coffeeOrderService;
+
+    @Autowired
+    private CoffeeService coffeeService;
+
+    @Autowired
+    private CoffeeRepository coffeeRepository;
+
+    @Autowired
+    private CoffeeOrderRepository coffeeOrderRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+
+
+    private Coffee genCoffee(String coffeeName) {
+
+        Coffee coffee = Coffee.builder()
+                .name(coffeeName)
+                .price((int) (Math.random() * 10000))
+                .img("imgLink")
+                .build();
+
+        return coffeeRepository.save(coffee);
+    }
+
+    private CoffeeOrder genCoffeeOrder(Coffee coffee, Order order, Integer quantity) {
+        CoffeeOrder coffeeOrder = CoffeeOrder.builder()
+                .coffee(coffee)
+                .order(order)
+                .quantity(quantity)
+                .build();
+
+        return coffeeOrderRepository.save(coffeeOrder);
+    }
+
+    @Test
+    @DisplayName("CoffeeOrder 생성 테스트")
+    void coffeeOrderSaveTest() throws Exception {
+
+        //given
+        Coffee test1 = genCoffee("test1");
+        Coffee test2 = genCoffee("test2");
+
+        Order testOrder = Order.builder()
+                .email("coffeeordertests@gmail.com")
+                .address("분당")
+                .postNum("456745")
+                .build();
+        orderRepository.save(testOrder);
+
+        Map<String, Integer> coffeeOrderRequestDtoMap = Map.of(
+                "test1",3
+                ,"test2",2
+        );
+
+        CoffeeOrder coffeeOrder1 = genCoffeeOrder(test1, testOrder, 3);
+        CoffeeOrder coffeeOrder2 = genCoffeeOrder(test2, testOrder, 2);
+
+
+
+        List<CoffeeOrder> expectedCoffeeOrders = new ArrayList<>(List.of(
+                coffeeOrder1, coffeeOrder2
+        ));
+        //순서보장이 안되서 테스트 실패하는 경우가 있어서 정렬 후 검증
+        expectedCoffeeOrders.sort(Comparator.comparing(o -> o.getCoffee().getName()));
+
+        //when
+        List<CoffeeOrder> actualCoffeeOrders=
+                coffeeOrderService.save(coffeeOrderRequestDtoMap, testOrder).getCoffeeOrders();
+        //순서보장이 안되서 테스트 실패하는 경우가 있어서 정렬 후 검증
+        actualCoffeeOrders.sort(Comparator.comparing(o -> o.getCoffee().getName()));
+
+
+        //then
+        assertEquals(expectedCoffeeOrders.size(), actualCoffeeOrders.size());
+        for (int i = 0; i < expectedCoffeeOrders.size(); i++) {
+            assertEquals(expectedCoffeeOrders.get(i).getCoffee().getName(), actualCoffeeOrders.get(i).getCoffee().getName());
+            assertEquals(expectedCoffeeOrders.get(i).getQuantity(), actualCoffeeOrders.get(i).getQuantity());
+        }
+
+        log.info("actualCoffeeOrders = {}", actualCoffeeOrders);
+
+    }
+
+}

--- a/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
+++ b/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
@@ -3,6 +3,7 @@ package io.sleepyhoon.project1.coffeeordertests;
 import io.sleepyhoon.project1.dao.CoffeeOrderRepository;
 import io.sleepyhoon.project1.dao.CoffeeRepository;
 import io.sleepyhoon.project1.dao.OrderRepository;
+import io.sleepyhoon.project1.dto.CoffeeListDto;
 import io.sleepyhoon.project1.dto.CoffeeOrderDto;
 import io.sleepyhoon.project1.dto.CoffeeRequestDto;
 import io.sleepyhoon.project1.entity.Coffee;
@@ -80,9 +81,9 @@ public class CoffeeOrderServiceTest {
                 .build();
         orderRepository.save(testOrder);
 
-        Map<String, Integer> coffeeOrderRequestDtoMap = Map.of(
-                "test1",3
-                ,"test2",2
+        List<CoffeeListDto> coffeeOrderRequestDtoMap = List.of(
+                new CoffeeListDto("test1",3),
+                new CoffeeListDto("test2", 2)
         );
 
         CoffeeOrder coffeeOrder1 = genCoffeeOrder(test1, testOrder, 3);
@@ -103,7 +104,6 @@ public class CoffeeOrderServiceTest {
         //순서보장이 안되서 테스트 실패하는 경우가 있어서 정렬 후 검증
         actualCoffeeOrders.sort(Comparator.comparing(o -> o.getCoffee().getName()));
 
-
         //then
         assertEquals(expectedCoffeeOrders.size(), actualCoffeeOrders.size());
         for (int i = 0; i < expectedCoffeeOrders.size(); i++) {
@@ -111,6 +111,10 @@ public class CoffeeOrderServiceTest {
             assertEquals(expectedCoffeeOrders.get(i).getQuantity(), actualCoffeeOrders.get(i).getQuantity());
         }
 
+        //가격소계 합 확인
+        log.info("actualCoffeeOrders.get(0).getCoffee().getPrice() = {}", actualCoffeeOrders.get(0).getCoffee().getPrice());
+        log.info("actualCoffeeOrders.get(0).getQuantity() = {}", actualCoffeeOrders.get(0).getQuantity());
+        log.info("actualCoffeeOrders.get(0).getSubtotalPrice() = {}", actualCoffeeOrders.get(0).getSubtotalPrice());
     }
 
 }

--- a/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
+++ b/src/test/java/io/sleepyhoon/project1/coffeeordertests/CoffeeOrderServiceTest.java
@@ -98,7 +98,7 @@ public class CoffeeOrderServiceTest {
 
         //when
         List<CoffeeOrder> actualCoffeeOrders=
-                coffeeOrderService.save(coffeeOrderRequestDtoMap, testOrder).getCoffeeOrders();
+                coffeeOrderService.save(coffeeOrderRequestDtoMap, testOrder);
         //순서보장이 안되서 테스트 실패하는 경우가 있어서 정렬 후 검증
         actualCoffeeOrders.sort(Comparator.comparing(o -> o.getCoffee().getName()));
 
@@ -109,8 +109,6 @@ public class CoffeeOrderServiceTest {
             assertEquals(expectedCoffeeOrders.get(i).getCoffee().getName(), actualCoffeeOrders.get(i).getCoffee().getName());
             assertEquals(expectedCoffeeOrders.get(i).getQuantity(), actualCoffeeOrders.get(i).getQuantity());
         }
-
-        log.info("actualCoffeeOrders = {}", actualCoffeeOrders);
 
     }
 


### PR DESCRIPTION
## 🛰️ Issue Number
#19 

## 🪐 작업 내용
- Order 컨트롤러로 온 요청에서 CoffeeOrder에 해당하는 부분을 추출한 Map과 Order를 매개변수로 받고,
이 정보를 통해 CoffeeOrder를 생성하여 List형식으로 반환하는 메서드입니다.
CoffeeOrder List를 Order 서비스에서 Order에 적용하여 Order를 완성하여 저장하는 목적이 있습니다.

- 메소드 이름을 genCoffeeOrderList()로 변경하였습니다.

- CoffeeOrder는 Order의 CRUD가 CoffeeOrder에 전파되도록


- Order의 CoffeeOrder필드에 cascade설정을 했기에 더 이상 genCoffeeOrderList()에서 CoffeeOrder를 저장하지 않고, 이후 Order서비스에서 CoffeeOrder 리스트를 추가하고 저장하면 상태 전파가 되는 식으로 설계했습니다.
Order.getCoffeeOrders().remove(x) 하면 해당 CoffeeOrder는 DB에서도 삭제되도록 orphanRemoval도 설정해두었습니다.
```
 @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true) 
```
```
//CoffeeOrder saved = coffeeOrderRepository.save(coffeeOrder);  이부분 주석처리
```

- 따로 테스트도 진행하였으나 테스트 과정에 의문이 있으시면 언제든 환영입니다! 저도 미심쩍습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?