### PR TITLE
Refactor: 주문페이지 POST json 형식 변경

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -212,8 +212,13 @@
 
     const orderJson = message + contents.join("\n") + deliveryMessage + deliveryInfo.join("\n");
 
+    const coffeeList = Object.entries(counts).map(([name, quantity]) => ({
+      coffeeName: name,
+      quantity: quantity
+    }));
+
     const data = {
-      "coffee-list": counts,
+      "coffee-list": coffeeList,
       "email": document.getElementById('email').value,
       "address": document.getElementById('address').value,
       "postnum": document.getElementById('postnum').value,


### PR DESCRIPTION
## 🛰️ Issue Number
#39 

## 🪐 작업 내용
원래 형식에서
```
{
   coffee-list: {
           cup: 3, 
           brown: 2
   },
   price: 12000,
   email: "ex@example.com",
   address: "Daehak-ro 291",
   postnum: "35141"
}
```
아래처럼 형식을 바꾸어 Order 측에서 처리하기 용이하도록 만들었습니다.
```
{
  coffee-list: {
      { coffeeName : "cup" quantity : 3},
      { coffeeName: “brown” quantity : 2}
  },
  price: 12000,
  email: "ex@example.com",
  address: "Daehak-ro 291",
  postnum: "35141"
}
```
- 콘솔에서 확인한 결과 :
<img src="https://github.com/user-attachments/assets/cc04a1b2-aeaa-4ed1-982f-555205166f1b" width=400>

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?