### PR TITLE
Feature: 관리자페이지 커피 이미지 표시되도록 수정

### DIFF
--- a/src/main/resources/static/js/admin.js
+++ b/src/main/resources/static/js/admin.js
@@ -28,7 +28,7 @@ function loadCoffees() {
                     <tr id="coffee-${coffee.id}">
                         <td class="name">${coffee.name}</td>
                         <td class="price">${coffee.price}원</td>
-                        <td class="img">${coffee.img}</td>
+                        <td class="img"><img src="${coffee.img}" height="50" width="auto" alt=""></td>
                         <td><button onclick="showEditForm(${coffee.id})">수정</button></td>
                         <td><button onclick="deleteCoffee(${coffee.id})">삭제</button></td>
                     </tr>

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -3,7 +3,12 @@
 <head>
     <meta charset="UTF-8" />
     <title>카페 관리자 페이지</title>
-    <script src="/js/admin.js"></script>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+
+  <script src="/js/admin.js"></script>
     <script src="/js/admin_api.js"></script>
     <link rel="stylesheet" href="/css/admin_style.css" />
 </head>


### PR DESCRIPTION
## 🛰️ Issue Number
#41 

## 🪐 작업 내용

기존에 이미지링크가 문자열로 표시되던 모습 :
<img src="https://github.com/user-attachments/assets/9a1cd3fb-0f11-4a51-8b1f-7672882616f4" width=600>   
<br/>

- **높이 50의 이미지로 표시되도록 수정하였습니다.**
`<td class="img"><img src="${coffee.img}" height="50" width="auto" alt=""></td>`
<img src="https://github.com/user-attachments/assets/beb32280-082f-49eb-ac91-2c0699c8f1b3" width=600>


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?