### PR TITLE
Refactor: Order 응답 객체를 OrderRequestDto에서 OrderResponseDto로 변경

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/controller/OrderController.java
+++ b/src/main/java/io/sleepyhoon/project1/controller/OrderController.java
@@ -3,6 +3,7 @@ package io.sleepyhoon.project1.controller;
 import io.sleepyhoon.project1.dto.ApiResponse;
 import io.sleepyhoon.project1.dto.OrderDto;
 import io.sleepyhoon.project1.dto.OrderRequestDto;
+import io.sleepyhoon.project1.dto.OrderResponseDto;
 import io.sleepyhoon.project1.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,19 +19,19 @@ public class OrderController {
     private final OrderService orderService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<OrderRequestDto>>> getAllOrders(@RequestParam String email) {
-        List<OrderRequestDto> orders = orderService.findAllOrdersByEmail(email);
+    public ResponseEntity<ApiResponse<List<OrderResponseDto>>> getAllOrders(@RequestParam String email) {
+        List<OrderResponseDto> orders = orderService.findAllOrdersByEmail(email);
         return ResponseEntity.ok(new ApiResponse<>(orders, "조회 성공", 200));
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<OrderRequestDto>> saveOrder(@RequestBody OrderRequestDto request) {
-        OrderRequestDto order = orderService.save(request);
+    public ResponseEntity<ApiResponse<OrderResponseDto>> saveOrder(@RequestBody OrderRequestDto request) {
+        OrderResponseDto order = orderService.save(request);
         return ResponseEntity.ok(new ApiResponse<>(order, "주문 성공", 201));
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<OrderRequestDto>> getOrderById(@PathVariable Long id) {
+    public ResponseEntity<ApiResponse<OrderResponseDto>> getOrderById(@PathVariable Long id) {
         return ResponseEntity.ok(new ApiResponse<>(orderService.findById(id), "조회 성공", 200));
     }
 

--- a/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
+++ b/src/main/java/io/sleepyhoon/project1/dao/OrderRepository.java
@@ -1,8 +1,7 @@
 package io.sleepyhoon.project1.dao;
 
 import io.sleepyhoon.project1.dto.CoffeeListDto;
-import io.sleepyhoon.project1.dto.OrderDto;
-import io.sleepyhoon.project1.dto.OrderRequestDto;
+import io.sleepyhoon.project1.dto.OrderResponseDto;
 import io.sleepyhoon.project1.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,10 +18,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findByEmail(@Param("email")String email);
 
-    @Query("SELECT new io.sleepyhoon.project1.dto.OrderRequestDto(o.price,o.email, o.address, o.postNum) " +
+    @Query("SELECT new io.sleepyhoon.project1.dto.OrderResponseDto(o.id, o.price, o.email, o.address, o.postNum) " +
             "FROM Order o " +
             "WHERE o.id = :id")
-    Optional<OrderRequestDto> findDtoById(@Param("id")Long id);
+    Optional<OrderResponseDto> findByIdAsDto(@Param("id")Long id);
 
     @Query("SELECT new io.sleepyhoon.project1.dto.CoffeeListDto(c.name, co.quantity) " +
             "FROM Order o " +

--- a/src/main/java/io/sleepyhoon/project1/dto/OrderResponseDto.java
+++ b/src/main/java/io/sleepyhoon/project1/dto/OrderResponseDto.java
@@ -1,6 +1,7 @@
 package io.sleepyhoon.project1.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -26,4 +27,14 @@ public class OrderResponseDto {
         this.postNum = postNum;
     }
 
+    @Builder
+
+    public OrderResponseDto(List<CoffeeListDto> coffeeList, Long id, Integer price, String email, String address, String postNum) {
+        this.coffeeList = coffeeList;
+        this.id = id;
+        this.price = price;
+        this.email = email;
+        this.address = address;
+        this.postNum = postNum;
+    }
 }

--- a/src/main/java/io/sleepyhoon/project1/dto/OrderResponseDto.java
+++ b/src/main/java/io/sleepyhoon/project1/dto/OrderResponseDto.java
@@ -1,29 +1,29 @@
 package io.sleepyhoon.project1.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.*;
+import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class OrderRequestDto {
+public class OrderResponseDto {
 
-    @JsonProperty("coffee-list") // JSON의 키와 다른 경우 매핑
+    @JsonProperty("coffee-list")
     private List<CoffeeListDto> coffeeList = new ArrayList<>();
 
+    private Long id;
     private Integer price;
     private String email;
     private String address;
     private String postNum;
 
-    public OrderRequestDto(Integer price, String email, String address, String postNum) {
+    public OrderResponseDto(Long id, Integer price, String email, String address, String postNum) {
+        this.id = id;
         this.price = price;
         this.email = email;
         this.address = address;
         this.postNum = postNum;
     }
-}
 
+}

--- a/src/main/java/io/sleepyhoon/project1/entity/Order.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Order.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -38,7 +39,7 @@ public class Order {
 
     @Setter
     @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<CoffeeOrder> coffeeOrders;
+    private List<CoffeeOrder> coffeeOrders = new ArrayList<>();
 
     @Builder
     public Order(String email, String address, String postNum, Integer price) {
@@ -48,4 +49,14 @@ public class Order {
         this.price = price;
     }
 
+    @Builder
+    public Order(String email, String address, String postNum, Integer price, LocalDateTime orderedAt, Boolean isProcessed, List<CoffeeOrder> coffeeOrders) {
+        this.email = email;
+        this.address = address;
+        this.postNum = postNum;
+        this.price = price;
+        this.orderedAt = orderedAt;
+        this.isProcessed = isProcessed;
+        this.coffeeOrders = coffeeOrders;
+    }
 }

--- a/src/main/java/io/sleepyhoon/project1/entity/Order.java
+++ b/src/main/java/io/sleepyhoon/project1/entity/Order.java
@@ -48,15 +48,4 @@ public class Order {
         this.postNum = postNum;
         this.price = price;
     }
-
-    @Builder
-    public Order(String email, String address, String postNum, Integer price, LocalDateTime orderedAt, Boolean isProcessed, List<CoffeeOrder> coffeeOrders) {
-        this.email = email;
-        this.address = address;
-        this.postNum = postNum;
-        this.price = price;
-        this.orderedAt = orderedAt;
-        this.isProcessed = isProcessed;
-        this.coffeeOrders = coffeeOrders;
-    }
 }

--- a/src/main/java/io/sleepyhoon/project1/service/OrderService.java
+++ b/src/main/java/io/sleepyhoon/project1/service/OrderService.java
@@ -41,13 +41,24 @@ public class OrderService {
 
         order.setCoffeeOrders(coffeeOrders);
 
-        OrderResponseDto orderResponseDto = new OrderResponseDto(order.getId(), order.getPrice(), order.getEmail(), order.getAddress(), order.getPostNum());
-        List<CoffeeListDto> coffeeList = orderResponseDto.getCoffeeList();
+        return OrderResponseDto.builder()
+                 .id(order.getId())
+                 .price(order.getPrice())
+                 .email(order.getEmail())
+                 .address(order.getAddress())
+                 .postNum(order.getPostNum())
+                 .coffeeList(toDtoList(coffeeOrders))
+                 .build();
+
+    }
+
+    private List<CoffeeListDto> toDtoList(List<CoffeeOrder> coffeeOrders) {
+        List<CoffeeListDto> coffeeListDtos = new ArrayList<>();
 
         for (CoffeeOrder coffeeOrder : coffeeOrders) {
-            coffeeList.add(new CoffeeListDto(coffeeOrder.getCoffee().getName(), coffeeOrder.getQuantity()));
+            coffeeListDtos.add(new CoffeeListDto(coffeeOrder.getCoffee().getName(), coffeeOrder.getQuantity()));
         }
-        return orderResponseDto;
+        return coffeeListDtos;
     }
 
     public List<OrderResponseDto> findAllOrdersByEmail(String email) {
@@ -56,9 +67,15 @@ public class OrderService {
         List<OrderResponseDto> orderResponseDtoList = new ArrayList<>();
 
         for (Order order : orderList) {
-            OrderResponseDto orderResponseDto = new OrderResponseDto(order.getId(), order.getPrice(), order.getEmail(), order.getAddress(), order.getPostNum());
-            orderResponseDto.setCoffeeList(orderRepository.findCoffeeListByOrderId(order.getId()));
-            orderResponseDtoList.add(orderResponseDto);
+            orderResponseDtoList.add(
+                    OrderResponseDto.builder()
+                        .id(order.getId())
+                        .email(order.getEmail())
+                        .address(order.getAddress())
+                        .postNum(order.getPostNum())
+                        .price(order.getPrice())
+                        .coffeeList(toDtoList(order.getCoffeeOrders()))
+                        .build());
         }
 
         return orderResponseDtoList;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -145,8 +145,8 @@
           <input type="text" class="form-control mb-1" id="address">
         </div>
         <div class="mb-3">
-          <label for="postnum" class="form-label">우편번호</label>
-          <input type="text" class="form-control" id="postnum">
+          <label for="postNum" class="form-label">우편번호</label>
+          <input type="text" class="form-control" id="postNum">
         </div>
         <div class="inform">당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
       </form>
@@ -169,14 +169,14 @@
     const totalPrice = parseInt(document.getElementById("total-price").textContent);
     const email = document.getElementById('email').value;
     const address = document.getElementById('address').value;
-    const postnum = document.getElementById('postnum').value;
+    const postNum = document.getElementById('postNum').value;
     console.log(totalPrice);
 
     if (totalPrice === 0){
       alert(`상품을 먼저 담아주세요.`);
       return;
     }
-    else if (!email || !address || !postnum) {
+    else if (!email || !address || !postNum) {
       alert(`모든 칸에 정보를 채워주시기 바랍니다.`);
       return;
     }
@@ -208,7 +208,7 @@
     const deliveryInfo = [];
     deliveryInfo.push("이메일 : " + email);
     deliveryInfo.push("주소 : " + address);
-    deliveryInfo.push("우편번호 : " + postnum);
+    deliveryInfo.push("우편번호 : " + postNum);
 
     const orderJson = message + contents.join("\n") + deliveryMessage + deliveryInfo.join("\n");
 
@@ -221,12 +221,12 @@
       "coffee-list": coffeeList,
       "email": document.getElementById('email').value,
       "address": document.getElementById('address').value,
-      "postnum": document.getElementById('postnum').value,
+      "postNum": document.getElementById('postNum').value,
       "price": totalPrice,
     };
 
     console.log(data);
-    fetch('http://localhost:8080/coffee', {
+    fetch('http://localhost:8080/orders', {
       method: "POST",
       headers: {
         //내가 보내는 요청의 본문에는 JSON형식이 들어있다는 걸 알려줘야 함


### PR DESCRIPTION
## 🛰️ Issue Number
#45 

## 🪐 작업 내용

#### 1. 기존 OrderRequestDto를 응답 객체로 재사용
```java
@PostMapping
    public ResponseEntity<ApiResponse<OrderRequestDto>> saveOrder(@RequestBody OrderRequestDto request) {
        OrderRequest order = orderService.save(request);
        return ResponseEntity.ok(new ApiResponse<>(order, "주문 성공", 201));
    }
```

#### 2. 요청과 응답 역할 분리를 위한 OrderResponseDto 생성 및 변경
```java
@PostMapping
    public ResponseEntity<ApiResponse<OrderResponseDto>> saveOrder(@RequestBody OrderRequestDto request) {
        OrderResponseDto order = orderService.save(request);
        return ResponseEntity.ok(new ApiResponse<>(order, "주문 성공", 201));
    }

```


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?