### PR TITLE
Feat: 사용자정보 기반 버튼, 문구 표시, restController 추가

### DIFF
--- a/src/main/java/io/sleepyhoon/project1/controller/AuthController.java
+++ b/src/main/java/io/sleepyhoon/project1/controller/AuthController.java
@@ -1,0 +1,25 @@
+package io.sleepyhoon.project1.controller;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    @GetMapping("/me")
+    public Map<String, Object> currentUserInfo(Authentication authentication) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("name", authentication.getName());
+        result.put("email", authentication.getPrincipal());
+        result.put("authorities", authentication.getAuthorities());
+        return result;
+    }
+
+
+}

--- a/src/main/java/io/sleepyhoon/project1/controller/AuthController.java
+++ b/src/main/java/io/sleepyhoon/project1/controller/AuthController.java
@@ -1,5 +1,6 @@
 package io.sleepyhoon.project1.controller;
 
+import io.sleepyhoon.project1.dto.MemberDetails;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,9 +16,12 @@ public class AuthController {
     @GetMapping("/me")
     public Map<String, Object> currentUserInfo(Authentication authentication) {
         Map<String, Object> result = new HashMap<>();
-        result.put("name", authentication.getName());
-        result.put("email", authentication.getPrincipal());
-        result.put("authorities", authentication.getAuthorities());
+
+        MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
+        result.put("email", memberDetails.getEmail());
+        result.put("username", memberDetails.getUsername());
+        result.put("role", memberDetails.getAuthorities());
+
         return result;
     }
 

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -13,6 +13,10 @@
     <link rel="stylesheet" href="/css/admin_style.css" />
 </head>
 <body>
+<div class="d-flex justify-content-end align-items-center mt-2 me-2" id="top-buttons">
+  <a href="/index" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none; width: auto; height: auto; white-space: nowrap; margin-right: 10px">주문 페이지로 돌아가기</a>
+  <a href="/logout" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none; width: auto; height: auto; white-space: nowrap;">로그아웃 하기</a>
+</div>
 <h1>카페 관리자 페이지 | Grid & Circles</h1>
 
 <!-- 새로운 커피 추가 -->

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -16,8 +16,43 @@
 </head>
 
 <body class="container-fluid">
-<div class="d-flex justify-content-end align-items-center mt-2 me-2">
-    <a href="/logout" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none">로그아웃 하기</a>
+
+<script>
+  fetch('http://localhost:8080/auth/me')
+  .then(resp => resp.json())
+  .then(user => {
+    console.log(`==============유저정보============`);
+    console.log(user);
+    const email = user.email.email;
+    const username = user.email.username;
+    const isAdmin = user.authorities.some(auth=> auth.authority === 'ADMIN' || auth.authority === 'ROLE_ADMIN');
+    console.log(isAdmin);
+    const buttonDiv = document.getElementById('top-buttons');
+
+    // buttonDiv.innerHTML = ``;
+    if (isAdmin) {
+      console.log(`관리자페이지버튼 추가`);
+      buttonDiv.innerHTML =  `<a href="/admin" class="btn btn-small btn-outline-dark" style="margin-right: 10px">관리자페이지</a>` + buttonDiv.innerHTML;
+    } else {
+      buttonDiv.innerHTML = `<a href="/user" class="btn btn-small btn-outline-dark" style="margin-right: 10px">마이페이지</a>` + buttonDiv.innerHTML;
+    }
+
+    const userinfo = document.getElementById('user-info');
+    userinfo.innerHTML =  `
+    <span style="font-size: 18px">현재 사용자 정보</span>
+    <hr style="margin-top: 10px;">
+    <h6>사용자 이름 | <span style="color: #606060;">${username}</span></h6>
+    <h6>이메일 | <span style="color: #606060;">${email}</span></h6>
+    <br>
+    `;
+
+  });
+</script>
+
+
+
+<div class="d-flex justify-content-end align-items-center mt-2 me-2" id="top-buttons">
+  <a href="/logout" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none; width: auto; height: auto; white-space: nowrap;">로그아웃 하기</a>
 </div>
 <div class="row justify-content-center m-4">
   <h1 class="text-center">Grids & Circle</h1>
@@ -138,18 +173,17 @@
       <div id="summary-list">
       </div>
 
-      <form id="delivery-info">
-        <div class="mb-3">
-          <label for="email" class="form-label">이메일</label>
-          <input type="email" class="form-control mb-1" id="email">
+      <form id="delivery-info" style="padding-top: 10%">
+
+        <div id="user-info">
         </div>
         <div class="mb-3">
           <label for="address" class="form-label">주소</label>
           <input type="text" class="form-control mb-1" id="address">
         </div>
         <div class="mb-3">
-          <label for="postNum" class="form-label">우편번호</label>
-          <input type="text" class="form-control" id="postNum">
+          <label for="postnum" class="form-label">우편번호</label>
+          <input type="text" class="form-control" id="postnum">
         </div>
         <div class="inform">당일 오후 2시 이후의 주문은 다음날 배송을 시작합니다.</div>
       </form>
@@ -170,16 +204,15 @@
   document.querySelector('.order-btn').addEventListener('click', function() {
 
     const totalPrice = parseInt(document.getElementById("total-price").textContent);
-    const email = document.getElementById('email').value;
     const address = document.getElementById('address').value;
-    const postNum = document.getElementById('postNum').value;
+    const postnum = document.getElementById('postnum').value;
     console.log(totalPrice);
 
     if (totalPrice === 0){
       alert(`상품을 먼저 담아주세요.`);
       return;
     }
-    else if (!email || !address || !postNum) {
+    else if (!address || !postnum) {
       alert(`모든 칸에 정보를 채워주시기 바랍니다.`);
       return;
     }
@@ -211,20 +244,15 @@
     const deliveryInfo = [];
     deliveryInfo.push("이메일 : " + email);
     deliveryInfo.push("주소 : " + address);
-    deliveryInfo.push("우편번호 : " + postNum);
+    deliveryInfo.push("우편번호 : " + postnum);
 
     const orderJson = message + contents.join("\n") + deliveryMessage + deliveryInfo.join("\n");
 
-    const coffeeList = Object.entries(counts).map(([name, quantity]) => ({
-      coffeeName: name,
-      quantity: quantity
-    }));
-
     const data = {
-      "coffee-list": coffeeList,
+      "coffee-list": counts,
       "email": document.getElementById('email').value,
       "address": document.getElementById('address').value,
-      "postNum": document.getElementById('postNum').value,
+      "postnum": document.getElementById('postnum').value,
       "price": totalPrice,
     };
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -23,9 +23,9 @@
   .then(user => {
     console.log(`==============유저정보============`);
     console.log(user);
-    const email = user.email.email;
-    const username = user.email.username;
-    const isAdmin = user.authorities.some(auth=> auth.authority === 'ADMIN' || auth.authority === 'ROLE_ADMIN');
+    const email = user.email;
+    const username = user.username;
+    const isAdmin = user.role.some(auth=> auth.authority === 'ADMIN' || auth.authority === 'ROLE_ADMIN');
     console.log(isAdmin);
     const buttonDiv = document.getElementById('top-buttons');
 

--- a/src/main/resources/templates/user.html
+++ b/src/main/resources/templates/user.html
@@ -3,10 +3,61 @@
 <head>
   <meta charset="UTF-8">
   <title>사용자 페이지 | Grid & Circles</title>
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+
+  <style>
+    @font-face {
+      font-family: 'Pretendard-Regular';
+      src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+      font-weight: 400;
+      font-style: normal;
+    }
+
+    * {
+      font-family: Pretendard-Regular;
+    }
+
+    body {
+      padding: 10%;
+      padding-top: 5%;
+      background: #f5f5f5;
+    }
+
+
+  </style>
 </head>
 <body>
 
-<h1>사용자 페이지입니다</h1>
+<script>
+  fetch('http://localhost:8080/auth/me')
+      .then(resp => resp.json())
+      .then(user => {
+        console.log(`==============유저정보============`);
+        console.log(user);
+        const username = user.name;
+        console.log(username);
+        document.querySelector('h3').textContent = `${username} 고객님의 주문목록`;
+      });
+</script>
 
+<div class="d-flex justify-content-end align-items-center mt-2 me-2" id="top-buttons">
+  <a href="/index" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none; width: auto; height: auto; white-space: nowrap; margin-right: 10px">주문 페이지로 돌아가기</a>
+  <a href="/logout" class="btn btn-small btn-outline-dark del-button" style="text-decoration: none; width: auto; height: auto; white-space: nowrap;">로그아웃 하기</a>
+</div>
+<br><br>
+<h3></h3>
+<hr>
+<br>
+<div>
+  <ul class="list-group">
+    <li class="list-group-item">An item</li>
+    <li class="list-group-item">A second item</li>
+    <li class="list-group-item">A third item</li>
+    <li class="list-group-item">A fourth item</li>
+    <li class="list-group-item">And a fifth one</li>
+  </ul>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## 🛰️ Issue Number
#55 

## 🪐 작업 내용
**1. RestController 추가해서 authentication 정보 응답하기**
localhost:8080/auth/me로 fetch를 실행하면 아래와 같은 json을 응답받을 수 있다.
```
{
    role: {authority: 'ADMIN'},
    username: "사용자이름",
    email: "user@user.com"
}
```
`authentication.getPrincipal()` 결과를 바로 돌려주면 인코딩된 비밀번호도 전달되기 때문에 `MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();`로 캐스팅 후 memberDetails에서 필요한 정보만 response에 넣어주었음
<br>

**2. 1을 이용하여 현재 로그인 상태 반영하여 버튼 표시**
- index.html 
    - fetch로 요청 보내서 authentication 정보 가져오기
    - ADMIN 권한으로 로그인 했을 경우 관리자페이지 버튼 생성
    - 다른 권한일 경우 마이페이지 버튼 생성
    - 이메일 입력 칸 삭제. 사용자 username, email 보여주는 칸 생성
<br>
- MEMBER 권한으로 로그인 한 경우. 빨간 박스 참고
<img src="https://github.com/user-attachments/assets/356525da-2592-416d-966e-34eaa21a68c7"> <br><br>
- ADMIN 권한으로 로그인 한 경우. 상단 우측에 마이페이지 대신 관리자페이지 버튼이 생성됨.
<img src="https://github.com/user-attachments/assets/ee0e93dc-8583-4e8a-9955-13cca80a3a8b" width=600>
<br><br>

- user.html
    - 주문페이지로 돌아가기, 로그아웃 버튼 추가
    - 주문목록 보여줄 디자인 추가
<img src="https://github.com/user-attachments/assets/886ac49b-2a50-417b-9d28-ba8a307eb45f" width=600>
<br><br>
- admin.html
    - 상단 우측에 주문페이지로 돌아가기, 로그아웃 버튼 추가
<img src="https://github.com/user-attachments/assets/20269b54-f08f-45c8-a620-3d6887c41a7a" width=600>

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?